### PR TITLE
Fix CAMB submodule revisions before applying patches

### DIFF
--- a/Cocoa/installation_scripts/setup_camb.sh
+++ b/Cocoa/installation_scripts/setup_camb.sh
@@ -108,7 +108,16 @@ if [ ! -d "${PACKDIR:?}" ]; then
     "${GIT:?}" checkout "tags/${CAMB_GIT_TAG:?}" -b "${CAMB_GIT_TAG:?}" \
       >>${OUT1:?} 2>>${OUT2:?} || { error "${EC16:?}"; return 1; }
   fi
-  
+  # Match submodules to the selected CAMB revision before applying patches.
+  "${GIT:?}" submodule sync --recursive >>"${OUT1:?}" 2>>"${OUT2:?}" || {
+    error "${EC16:?}"
+    return 1
+  }
+
+  "${GIT:?}" submodule update --init --recursive >>"${OUT1:?}" 2>>"${OUT2:?}" || {
+    error "${EC16:?}"
+    return 1
+  }
   # --------------------------------------------------------------------------
   # We patch the files below so they use the right compilers -----------------
   # --------------------------------------------------------------------------


### PR DESCRIPTION
**Problem**
`setup_camb.sh` recursively clones CAMB and then checks out the configured CAMB commit, branch, or tag. It does not subsequently update the submodules to match that version. 

This can leave `forutils` at a different commit from the one recorded by the selected CAMB revision, causing Cocoa's compiler patch to fail:

SHELL SCRIPT FILE PATCH FAILED (Makefile_compiler)

**Change**
After the CAMB checkout block and before applying the compiler patches, this PR adds:

git submodule sync --recursive
git submodule update --init --recursive

The commands use Cocoa's configured Git executable, output redirection, and error handling. Setup returns with a error if either command fails.

**Validation**
I encountered this patch failure with the stable Cocoa installation on Linux. Adding these commands and rerunning `setup_camb.sh` with a fresh CAMB checkout resolved the patch failure in my installation. After setup completes successfully, run `compile_camb.sh` to compile CAMB.

The equivalent change is proposed here against `main`. I have not validated a complete installation of this branch on macOS.

**Related issue**
Related to #90 , which reports the same `Makefile_compiler` patch error on macOS. Confirmation from the reporter is needed to establish whether this also resolves this installation failure.